### PR TITLE
Fix `compose_stream_resource` calls

### DIFF
--- a/src/ophyd_async/epics/areadetector/writers/_hdffile.py
+++ b/src/ophyd_async/epics/areadetector/writers/_hdffile.py
@@ -25,7 +25,7 @@ class _HDFFile:
         self._bundles = [
             compose_stream_resource(
                 mimetype="application/x-hdf5",
-                uri=f"file://{full_file_name}",
+                uri=f"file://localhost{full_file_name}",
                 # spec="AD_HDF5_SWMR_SLICE",
                 # root=str(path_info.root),
                 data_key=ds.name,

--- a/src/ophyd_async/epics/areadetector/writers/_hdffile.py
+++ b/src/ophyd_async/epics/areadetector/writers/_hdffile.py
@@ -26,10 +26,7 @@ class _HDFFile:
             compose_stream_resource(
                 mimetype="application/x-hdf5",
                 uri=f"file://localhost{full_file_name}",
-                # spec="AD_HDF5_SWMR_SLICE",
-                # root=str(path_info.root),
                 data_key=ds.name,
-                # resource_path=str(full_file_name.relative_to(path_info.root)),
                 parameters={
                     "path": ds.path,
                     "multiplier": ds.multiplier,

--- a/src/ophyd_async/epics/areadetector/writers/_hdffile.py
+++ b/src/ophyd_async/epics/areadetector/writers/_hdffile.py
@@ -24,11 +24,13 @@ class _HDFFile:
         self._last_emitted = 0
         self._bundles = [
             compose_stream_resource(
-                spec="AD_HDF5_SWMR_SLICE",
-                root=str(path_info.root),
+                mimetype="application/x-hdf5",
+                uri=f"file://{full_file_name}",
+                # spec="AD_HDF5_SWMR_SLICE",
+                # root=str(path_info.root),
                 data_key=ds.name,
-                resource_path=str(full_file_name.relative_to(path_info.root)),
-                resource_kwargs={
+                # resource_path=str(full_file_name.relative_to(path_info.root)),
+                parameters={
                     "path": ds.path,
                     "multiplier": ds.multiplier,
                     "timestamps": "/entry/instrument/NDAttributes/NDArrayTimeStamp",

--- a/src/ophyd_async/panda/writers/_hdf_writer.py
+++ b/src/ophyd_async/panda/writers/_hdf_writer.py
@@ -207,7 +207,8 @@ class PandaHDFWriter(DetectorWriter):
             if not self._file:
                 self._file = _HDFFile(
                     self._path_provider(),
-                    Path(await self.panda_device.data.hdf_file_name.get_value()),
+                    Path(await self.panda_device.data.hdf_directory.get_value())
+                    / Path(await self.panda_device.data.hdf_file_name.get_value()),
                     self._datasets,
                 )
                 for doc in self._file.stream_resources():

--- a/src/ophyd_async/panda/writers/_panda_hdf_file.py
+++ b/src/ophyd_async/panda/writers/_panda_hdf_file.py
@@ -29,10 +29,7 @@ class _HDFFile:
             compose_stream_resource(
                 mimetype="application/x-hdf5",
                 uri=f"file://localhost{path_info.root / full_file_name}",
-                # spec="AD_HDF5_SWMR_SLICE",
-                # root=str(path_info.root),
                 data_key=ds.name,
-                # resource_path=(f"{str(path_info.root)}/{full_file_name}"),
                 parameters={
                     "name": ds.name,
                     "block": ds.block,

--- a/src/ophyd_async/panda/writers/_panda_hdf_file.py
+++ b/src/ophyd_async/panda/writers/_panda_hdf_file.py
@@ -27,11 +27,13 @@ class _HDFFile:
         self._last_emitted = 0
         self._bundles = [
             compose_stream_resource(
-                spec="AD_HDF5_SWMR_SLICE",
-                root=str(path_info.root),
+                mimetype="application/x-hdf5",
+                uri=f"file://{full_file_name}",
+                # spec="AD_HDF5_SWMR_SLICE",
+                # root=str(path_info.root),
                 data_key=ds.name,
-                resource_path=(f"{str(path_info.root)}/{full_file_name}"),
-                resource_kwargs={
+                # resource_path=(f"{str(path_info.root)}/{full_file_name}"),
+                parameters={
                     "name": ds.name,
                     "block": ds.block,
                     "path": ds.path,

--- a/src/ophyd_async/panda/writers/_panda_hdf_file.py
+++ b/src/ophyd_async/panda/writers/_panda_hdf_file.py
@@ -28,7 +28,7 @@ class _HDFFile:
         self._bundles = [
             compose_stream_resource(
                 mimetype="application/x-hdf5",
-                uri=f"file://{full_file_name}",
+                uri=f"file://localhost{path_info.root / full_file_name}",
                 # spec="AD_HDF5_SWMR_SLICE",
                 # root=str(path_info.root),
                 data_key=ds.name,

--- a/src/ophyd_async/sim/pattern_generator.py
+++ b/src/ophyd_async/sim/pattern_generator.py
@@ -99,8 +99,6 @@ class HdfStreamProvider:
         full_file_name: Path,
         datasets: List[DatasetConfig],
     ) -> List[StreamAsset]:
-        # path = str(full_file_name.relative_to(path_info.root))
-        # root = str(path_info.root)
         bundler_composer = ComposeStreamResource()
 
         bundles: List[ComposeStreamResourceBundle] = []
@@ -109,9 +107,6 @@ class HdfStreamProvider:
             bundler_composer(
                 mimetype="application/x-hdf5",
                 uri=f"file://{full_file_name}",
-                # spec=SLICE_NAME,
-                # root=root,
-                # resource_path=path,
                 data_key=d.name.replace("/", "_"),
                 parameters={
                     "path": d.path,

--- a/src/ophyd_async/sim/pattern_generator.py
+++ b/src/ophyd_async/sim/pattern_generator.py
@@ -107,11 +107,13 @@ class HdfStreamProvider:
 
         bundles = [
             bundler_composer(
-                spec=SLICE_NAME,
-                root=root,
-                resource_path=path,
+                mimetype="application/x-hdf5",
+                uri=f"file://{full_file_name}",
+                # spec=SLICE_NAME,
+                # root=root,
+                # resource_path=path,
                 data_key=d.name.replace("/", "_"),
-                resource_kwargs={
+                parameters={
                     "path": d.path,
                     "multiplier": d.multiplier,
                     "timestamps": "/entry/instrument/NDAttributes/NDArrayTimeStamp",

--- a/src/ophyd_async/sim/pattern_generator.py
+++ b/src/ophyd_async/sim/pattern_generator.py
@@ -99,8 +99,8 @@ class HdfStreamProvider:
         full_file_name: Path,
         datasets: List[DatasetConfig],
     ) -> List[StreamAsset]:
-        path = str(full_file_name.relative_to(path_info.root))
-        root = str(path_info.root)
+        # path = str(full_file_name.relative_to(path_info.root))
+        # root = str(path_info.root)
         bundler_composer = ComposeStreamResource()
 
         bundles: List[ComposeStreamResourceBundle] = []

--- a/tests/core/test_flyer.py
+++ b/tests/core/test_flyer.py
@@ -85,10 +85,7 @@ class DummyWriter(DetectorWriter):
                 self._file = compose_stream_resource(
                     mimetype="application/x-hdf5",
                     uri="file://",
-                    # spec="AD_HDF5_SWMR_SLICE",
-                    # root="/",
                     data_key=self._name,
-                    # resource_path="",
                     parameters={
                         "path": "",
                         "multiplier": 1,

--- a/tests/core/test_flyer.py
+++ b/tests/core/test_flyer.py
@@ -84,7 +84,7 @@ class DummyWriter(DetectorWriter):
             if not self._file:
                 self._file = compose_stream_resource(
                     mimetype="application/x-hdf5",
-                    uri=f"file://",
+                    uri="file://",
                     # spec="AD_HDF5_SWMR_SLICE",
                     # root="/",
                     data_key=self._name,

--- a/tests/core/test_flyer.py
+++ b/tests/core/test_flyer.py
@@ -83,11 +83,13 @@ class DummyWriter(DetectorWriter):
         if indices_written:
             if not self._file:
                 self._file = compose_stream_resource(
-                    spec="AD_HDF5_SWMR_SLICE",
-                    root="/",
+                    mimetype="application/x-hdf5",
+                    uri=f"file://",
+                    # spec="AD_HDF5_SWMR_SLICE",
+                    # root="/",
                     data_key=self._name,
-                    resource_path="",
-                    resource_kwargs={
+                    # resource_path="",
+                    parameters={
                         "path": "",
                         "multiplier": 1,
                         "timestamps": "/entry/instrument/NDAttributes/NDArrayTimeStamp",

--- a/tests/plan_stubs/test_fly.py
+++ b/tests/plan_stubs/test_fly.py
@@ -68,11 +68,13 @@ class DummyWriter(DetectorWriter):
         if indices_written:
             if not self._file:
                 self._file = compose_stream_resource(
-                    spec="AD_HDF5_SWMR_SLICE",
-                    root="/",
+                    mimetype="application/x-hdf5",
+                    uri=f"file://",
+                    # spec="AD_HDF5_SWMR_SLICE",
+                    # root="/",
                     data_key=self._name,
-                    resource_path="",
-                    resource_kwargs={
+                    # resource_path="",
+                    parameters={
                         "path": "",
                         "multiplier": 1,
                         "timestamps": "/entry/instrument/NDAttributes/NDArrayTimeStamp",

--- a/tests/plan_stubs/test_fly.py
+++ b/tests/plan_stubs/test_fly.py
@@ -69,7 +69,7 @@ class DummyWriter(DetectorWriter):
             if not self._file:
                 self._file = compose_stream_resource(
                     mimetype="application/x-hdf5",
-                    uri=f"file://",
+                    uri="file://",
                     # spec="AD_HDF5_SWMR_SLICE",
                     # root="/",
                     data_key=self._name,

--- a/tests/plan_stubs/test_fly.py
+++ b/tests/plan_stubs/test_fly.py
@@ -70,10 +70,7 @@ class DummyWriter(DetectorWriter):
                 self._file = compose_stream_resource(
                     mimetype="application/x-hdf5",
                     uri="file://",
-                    # spec="AD_HDF5_SWMR_SLICE",
-                    # root="/",
                     data_key=self._name,
-                    # resource_path="",
                     parameters={
                         "path": "",
                         "multiplier": 1,


### PR DESCRIPTION
This is to work with `event-model` >=1.21.0. We should also add a minimum version of `event-model` into `pyproject.toml`.