### PR TITLE
Some suggestions

### DIFF
--- a/src/ophyd_async/epics/adaravis/_aravis_controller.py
+++ b/src/ophyd_async/epics/adaravis/_aravis_controller.py
@@ -29,19 +29,6 @@ class AravisController(adcore.ADBaseController[AravisDriverIO]):
         super().__init__(driver, good_states=good_states)
         self.gpio_number = gpio_number
 
-    @classmethod
-    def controller_and_drv(
-        cls: type[AravisControllerT],
-        prefix: str,
-        good_states: frozenset[adcore.DetectorState] = adcore.DEFAULT_GOOD_STATES,
-        name: str = "",
-        gpio_number: GPIO_NUMBER = 1,
-    ) -> tuple[AravisControllerT, AravisDriverIO]:
-        driver_cls = get_args(cls.__orig_bases__[0])[0]  # type: ignore
-        driver = driver_cls(prefix, name=name)
-        controller = cls(driver, good_states=good_states, gpio_number=gpio_number)
-        return controller, driver
-
     def get_deadtime(self, exposure: float | None) -> float:
         return _HIGHEST_POSSIBLE_DEADTIME
 

--- a/src/ophyd_async/epics/adcore/_core_detector.py
+++ b/src/ophyd_async/epics/adcore/_core_detector.py
@@ -1,35 +1,24 @@
 from collections.abc import Sequence
 
-from ophyd_async.core import PathProvider, SignalR, StandardDetector
+from ophyd_async.core import SignalR, StandardDetector
 
-from ._core_io import ADBaseDatasetDescriber, ADBaseIO, NDPluginBaseIO
+from ._core_io import ADBaseIO, NDFileIO, NDPluginBaseIO
 from ._core_logic import ADBaseControllerT
-from ._core_writer import ADWriterT
+from ._core_writer import ADWriter
 
 
-class AreaDetector(StandardDetector[ADBaseControllerT, ADWriterT]):
+class AreaDetector(StandardDetector[ADBaseControllerT, ADWriter]):
     def __init__(
         self,
-        prefix: str,
         driver: ADBaseIO,
         controller: ADBaseControllerT,
-        writer_cls: type[ADWriterT],
-        path_provider: PathProvider,
+        writer: ADWriter[NDFileIO],
         plugins: dict[str, NDPluginBaseIO] | None,
         config_sigs: Sequence[SignalR] = (),
         name: str = "",
-        fileio_suffix: str | None = None,
     ):
         self.drv = driver
-        writer, self.fileio = writer_cls.writer_and_io(
-            prefix + (fileio_suffix or writer_cls.default_suffix),
-            path_provider,
-            lambda: name,
-            ADBaseDatasetDescriber(self.drv),
-            plugins=plugins,
-            name=name,
-        )
-
+        self.fileio = writer.fileio
         if plugins is not None:
             for name, plugin in plugins.items():
                 setattr(self, name, plugin)

--- a/src/ophyd_async/epics/adcore/_core_logic.py
+++ b/src/ophyd_async/epics/adcore/_core_logic.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Generic, TypeVar, get_args
+from typing import Any, Generic, TypeVar
 
 from ophyd_async.core import (
     DEFAULT_TIMEOUT,
@@ -33,22 +33,6 @@ class ADBaseController(DetectorController, Generic[ADBaseIOT]):
         self.good_states = good_states
         self.frame_timeout = DEFAULT_TIMEOUT
         self._arm_status: AsyncStatus | None = None
-
-    @classmethod
-    def controller_and_drv(
-        cls: type[ADBaseControllerT],
-        prefix: str,
-        good_states: frozenset[DetectorState] = DEFAULT_GOOD_STATES,
-        name: str = "",
-    ) -> tuple[ADBaseControllerT, ADBaseIOT]:
-        try:
-            driver_cls = get_args(cls.__orig_bases__[0])[0]  # type: ignore
-        except IndexError as err:
-            raise RuntimeError("Driver IO class for controller not specified!") from err
-
-        driver = driver_cls(prefix, name=name)
-        controller = cls(driver, good_states=good_states)
-        return controller, driver
 
     def get_deadtime(self, exposure: float | None) -> float:
         return 0.002

--- a/src/ophyd_async/epics/adcore/_hdf_writer.py
+++ b/src/ophyd_async/epics/adcore/_hdf_writer.py
@@ -54,13 +54,13 @@ class ADHDFWriter(ADWriter[NDFileHDFIO]):
         # Setting HDF writer specific signals
 
         # Make sure we are using chunk auto-sizing
-        await asyncio.gather(self._fileio.chunk_size_auto.set(True))
+        await asyncio.gather(self.fileio.chunk_size_auto.set(True))
 
         await asyncio.gather(
-            self._fileio.num_extra_dims.set(0),
-            self._fileio.lazy_open.set(True),
-            self._fileio.swmr_mode.set(True),
-            self._fileio.xml_file_name.set(""),
+            self.fileio.num_extra_dims.set(0),
+            self.fileio.lazy_open.set(True),
+            self.fileio.swmr_mode.set(True),
+            self.fileio.xml_file_name.set(""),
         )
 
         # By default, don't add file number to filename
@@ -78,7 +78,7 @@ class ADHDFWriter(ADWriter[NDFileHDFIO]):
         outer_shape = (multiplier,) if multiplier > 1 else ()
 
         # Determine number of frames that will be saved per HDF chunk
-        frames_per_chunk = await self._fileio.num_frames_chunks.get_value()
+        frames_per_chunk = await self.fileio.num_frames_chunks.get_value()
 
         # Add the main data
         self._datasets = [
@@ -124,7 +124,7 @@ class ADHDFWriter(ADWriter[NDFileHDFIO]):
 
         describe = {
             ds.data_key: DataKey(
-                source=self._fileio.full_file_name.source,
+                source=self.fileio.full_file_name.source,
                 shape=list(outer_shape + tuple(ds.shape)),
                 dtype="array" if ds.shape else "number",
                 dtype_numpy=ds.dtype_numpy,
@@ -138,10 +138,10 @@ class ADHDFWriter(ADWriter[NDFileHDFIO]):
         self, indices_written: int
     ) -> AsyncIterator[StreamAsset]:
         # TODO: fail if we get dropped frames
-        await self._fileio.flush_now.set(True)
+        await self.fileio.flush_now.set(True)
         if indices_written:
             if not self._file:
-                path = Path(await self._fileio.full_file_name.get_value())
+                path = Path(await self.fileio.full_file_name.get_value())
                 self._file = HDFFile(
                     # See https://github.com/bluesky/ophyd-async/issues/122
                     path,
@@ -158,8 +158,8 @@ class ADHDFWriter(ADWriter[NDFileHDFIO]):
 
     async def close(self):
         # Already done a caput callback in _capture_status, so can't do one here
-        await self._fileio.capture.set(False, wait=False)
-        await wait_for_value(self._fileio.capture, False, DEFAULT_TIMEOUT)
+        await self.fileio.capture.set(False, wait=False)
+        await wait_for_value(self.fileio.capture, False, DEFAULT_TIMEOUT)
         if self._capture_status:
             # We kicked off an open, so wait for it to return
             await self._capture_status

--- a/src/ophyd_async/epics/adcore/_tiff_writer.py
+++ b/src/ophyd_async/epics/adcore/_tiff_writer.py
@@ -24,4 +24,4 @@ class ADTIFFWriter(ADWriter[NDFileIO]):
             file_extension=".tiff",
             mimetype="multipart/related;type=image/tiff",
         )
-        self.tiff = self._fileio
+        self.tiff = self.fileio

--- a/src/ophyd_async/epics/adkinetix/_kinetix.py
+++ b/src/ophyd_async/epics/adkinetix/_kinetix.py
@@ -23,9 +23,7 @@ class KinetixDetector(AreaDetector[KinetixController, ADWriter]):
         plugins: dict[str, NDPluginBaseIO] | None = None,
         config_sigs: Sequence[SignalR] = (),
     ):
-        controller, driver = KinetixController.controller_and_drv(
-            prefix + drv_suffix, name=name
-        )
+        controller, driver = KinetixController.with_io(prefix + drv_suffix, name=name)
 
         super().__init__(
             prefix=prefix,

--- a/tests/epics/adcore/test_scans.py
+++ b/tests/epics/adcore/test_scans.py
@@ -80,7 +80,7 @@ async def test_hdf_writer_fails_on_timeout_with_stepscan(
     writer: adcore.ADHDFWriter,
     controller: adcore.ADBaseController,
 ):
-    set_mock_value(writer._fileio.file_path_exists, True)
+    set_mock_value(writer.fileio.file_path_exists, True)
     detector: StandardDetector[Any, Any] = StandardDetector(
         controller, writer, name="detector"
     )
@@ -96,7 +96,7 @@ def test_hdf_writer_fails_on_timeout_with_flyscan(
     RE: RunEngine, writer: adcore.ADHDFWriter
 ):
     controller = DummyController()
-    set_mock_value(writer._fileio.file_path_exists, True)
+    set_mock_value(writer.fileio.file_path_exists, True)
 
     detector: StandardDetector[Any, Any] = StandardDetector(controller, writer)
     trigger_logic = DummyTriggerLogic()

--- a/tests/epics/adcore/test_writers.py
+++ b/tests/epics/adcore/test_writers.py
@@ -107,7 +107,7 @@ async def test_stats_describe_when_plugin_configured(
     hdf_writer_with_stats: adcore.ADHDFWriter,
 ):
     assert hdf_writer_with_stats._file is None
-    set_mock_value(hdf_writer_with_stats._fileio.file_path_exists, True)
+    set_mock_value(hdf_writer_with_stats.fileio.file_path_exists, True)
     assert hdf_writer_with_stats._plugins is not None
     set_mock_value(
         hdf_writer_with_stats._plugins["stats"].nd_attributes_file,
@@ -160,7 +160,7 @@ async def test_stats_describe_raises_error_with_dbr_native(
     hdf_writer_with_stats: adcore.ADHDFWriter,
 ):
     assert hdf_writer_with_stats._file is None
-    set_mock_value(hdf_writer_with_stats._fileio.file_path_exists, True)
+    set_mock_value(hdf_writer_with_stats.fileio.file_path_exists, True)
     assert hdf_writer_with_stats._plugins is not None
     set_mock_value(
         hdf_writer_with_stats._plugins["stats"].nd_attributes_file,

--- a/tests/epics/adsimdetector/test_sim.py
+++ b/tests/epics/adsimdetector/test_sim.py
@@ -55,7 +55,7 @@ def count_sim(dets: Sequence[adsimdetector.SimDetector], times: int = 1):
     for _ in range(times):
         read_values = {}
         for det in dets:
-            read_values[det] = yield from bps.rd(det._writer._fileio.num_captured)
+            read_values[det] = yield from bps.rd(det._writer.fileio.num_captured)
 
         for det in dets:
             yield from bps.trigger(det, wait=False, group="wait_for_trigger")
@@ -63,7 +63,7 @@ def count_sim(dets: Sequence[adsimdetector.SimDetector], times: int = 1):
         yield from bps.sleep(1.0)
         [
             set_mock_value(
-                det._writer._fileio.num_captured,
+                det._writer.fileio.num_captured,
                 read_values[det] + 1,
             )
             for det in dets
@@ -154,7 +154,7 @@ async def test_two_detectors_step(
     RE.subscribe(lambda name, _: names.append(name))
     RE.subscribe(lambda _, doc: docs.append(doc))
     [
-        set_mock_value(det._writer._fileio.file_path_exists, True)
+        set_mock_value(det._writer.fileio.file_path_exists, True)
         for det in two_test_adsimdetectors
     ]
 
@@ -174,22 +174,22 @@ async def test_two_detectors_step(
         assert False is (yield from bps.rd(drv.acquire))
         assert adcore.ImageMode.multiple == (yield from bps.rd(drv.image_mode))
 
-        hdfb = cast(adcore.NDFileHDFIO, writer_b._fileio)
+        hdfb = cast(adcore.NDFileHDFIO, writer_b.fileio)
         assert True is (yield from bps.rd(hdfb.lazy_open))
         assert True is (yield from bps.rd(hdfb.swmr_mode))
         assert 0 == (yield from bps.rd(hdfb.num_capture))
         assert adcore.FileWriteMode.stream == (yield from bps.rd(hdfb.file_write_mode))
 
-        assert (yield from bps.rd(writer_a._fileio.file_path)) == str(
+        assert (yield from bps.rd(writer_a.fileio.file_path)) == str(
             info_a.directory_path
         )
-        file_name_a = yield from bps.rd(writer_a._fileio.file_name)
+        file_name_a = yield from bps.rd(writer_a.fileio.file_name)
         assert file_name_a == info_a.filename
 
-        assert (yield from bps.rd(writer_b._fileio.file_path)) == str(
+        assert (yield from bps.rd(writer_b.fileio.file_path)) == str(
             info_b.directory_path
         )
-        file_name_b = yield from bps.rd(writer_b._fileio.file_name)
+        file_name_b = yield from bps.rd(writer_b.fileio.file_name)
         assert file_name_b == info_b.filename
 
     RE(plan())
@@ -247,13 +247,13 @@ async def test_detector_writes_to_file(
     RE.subscribe(lambda name, _: names.append(name))
     RE.subscribe(lambda _, doc: docs.append(doc))
     set_mock_value(
-        test_adsimdetector._writer._fileio.file_path_exists,
+        test_adsimdetector._writer.fileio.file_path_exists,
         True,
     )
 
     RE(count_sim([test_adsimdetector], times=3))
 
-    assert await test_adsimdetector._writer._fileio.file_path.get_value() == str(
+    assert await test_adsimdetector._writer.fileio.file_path.get_value() == str(
         tmp_path
     )
 

--- a/tests/epics/conftest.py
+++ b/tests/epics/conftest.py
@@ -28,7 +28,8 @@ def ad_standard_det_factory(
         with DeviceCollector(mock=True):
             prefix = f"{detector_name.upper()}{number}:"
             name = f"test_ad{detector_name.lower()}{number}"
-
+            # Can't do this anymore, but do we need to?
+            # Can we use AravisDetector instead?
             controller, driver = controller_cls.controller_and_drv(
                 prefix + "cam1:", name=name
             )
@@ -46,21 +47,21 @@ def ad_standard_det_factory(
         def on_set_file_path_callback(value: str, wait: bool = True):
             if os.path.exists(value):
                 set_mock_value(
-                    test_adstandard_det._writer._fileio.file_path_exists, True
+                    test_adstandard_det._writer.fileio.file_path_exists, True
                 )
                 set_mock_value(
-                    test_adstandard_det._writer._fileio.full_file_name,
+                    test_adstandard_det._writer.fileio.full_file_name,
                     f"{value}/{static_path_provider._filename_provider(device_name=test_adstandard_det.name)}{test_adstandard_det._writer._file_extension}",
                 )
 
         callback_on_mock_put(
-            test_adstandard_det._writer._fileio.file_path, on_set_file_path_callback
+            test_adstandard_det._writer.fileio.file_path, on_set_file_path_callback
         )
 
         # Set some sensible defaults to mimic a real detector setup
         set_mock_value(test_adstandard_det.drv.acquire_time, (number - 0.2))
         set_mock_value(test_adstandard_det.drv.acquire_period, float(number))
-        set_mock_value(test_adstandard_det._writer._fileio.capture, True)
+        set_mock_value(test_adstandard_det._writer.fileio.capture, True)
 
         # Set number of frames per chunk and frame dimensions to something reasonable
         set_mock_value(test_adstandard_det.drv.array_size_x, (9 + number))


### PR DESCRIPTION
- Writing contrller_and_drv in every ADBaseController seems repetitive
- I would like to have `AreaDetector.__init__` take driver, controller, writer
- If we make ADWriter.fileio public we don't need to pass it
- Doing the same for ADBaseController loses type information as we can't doubly dereference type hints
- This is not an issue for ADWriter as we pass in the class to AravisDetector in the first place so don't get those hints
- This makes AravisDetector a little smaller
- Why does generate_ad_standard_det() make an AreaDetector itself rather than using AravisDetector directly?